### PR TITLE
特殊時限のチェックもクリアできるように設定

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,6 +78,10 @@ window.onload = function () {
 		checkPerson.checked = false;
 		checkRoom.checked = false;
 		checkAbstract.checked = false;
+
+		checkConcentration.checked = false;
+		checkNegotiable.checked = false;
+		checkAsNeeded.checked = false;
 	});
 
 


### PR DESCRIPTION
検索条件をクリアしたときに、集中などといった特殊時限のチェックが外されないので、外されるようにしました。