### PR TITLE
GitHub Actionsのエラーの回避

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,5 @@ jobs:
           git config --global user.name "GitHub Action"
           git add .
           git commit -m "update csv: $(date +%Y%m%d)"
+          git pull origin master
           git push origin master


### PR DESCRIPTION
`.github/workflows/main.yml`がgit push時にエラーになっていたようなので、`git pull origin master`を追加しました。
加えて、現行の設定ですとpushが制限されているので、応急的な措置としてmasterブランチへの Restrict who can push to matching branches を解除しました。