### PR TITLE
お気に入りの保存先をCookieからLocalStorageに変更

### DIFF
--- a/script.js
+++ b/script.js
@@ -567,7 +567,6 @@ function onBookmarkChanged(event) {
 		}
 		value = encodeURIComponent(value.substr(1, value.length - 1))
 		document.cookie = "bookmarks=" + value + "; path=/; expires=Tue, 31-Dec-2037 00:00:00 GMT; "
-
 	}
 
 	const addBookmark = (subjectId) => {

--- a/script.js
+++ b/script.js
@@ -545,15 +545,8 @@ window.onload = function () {
 
 // Bookmark
 function getBookmarks() {
-	let cookies = [];
-	if (document.cookie !== '') {
-		let split = document.cookie.split('; ')
-		for (let i = 0; i < split.length; i++) {
-			let data = split[i].split('=');
-			cookies[data[0]] = decodeURIComponent(data[1])
-		}
-	}
-	if (cookies['bookmarks'] != null) return cookies['bookmarks'].split(',');
+	let value = localStorage.getItem('kdb_bookmarks');
+	if (value != null) return decodeURIComponent(value).split(',');
 	else return [];
 }
 
@@ -565,12 +558,12 @@ function onBookmarkChanged(event) {
 		for (let i = 0; i < bookmarks.length; i++) {
 			value += "," + bookmarks[i];
 		}
-		value = encodeURIComponent(value.substr(1, value.length - 1))
-		document.cookie = "bookmarks=" + value + "; path=/; expires=Tue, 31-Dec-2037 00:00:00 GMT; "
+		value = encodeURIComponent(value.substr(1, value.length - 1));
+		localStorage.setItem('kdb_bookmarks', value);
 	}
 
 	const addBookmark = (subjectId) => {
-		let bookmarks = getBookmarks()
+		let bookmarks = getBookmarks();
 		if (bookmarks.includes(subjectId)) {
 			return false;
 
@@ -581,7 +574,7 @@ function onBookmarkChanged(event) {
 	}
 
 	const removeBookmark = (subjectId) => {
-		let bookmarks = getBookmarks()
+		let bookmarks = getBookmarks();
 		if (!bookmarks.includes(subjectId)) {
 			return false;
 

--- a/script.js
+++ b/script.js
@@ -566,7 +566,7 @@ function onBookmarkChanged(event) {
 			value += "," + bookmarks[i];
 		}
 		value = encodeURIComponent(value.substr(1, value.length - 1))
-		document.cookie = "bookmarks=" + value + "; path=/"
+		document.cookie = "bookmarks=" + value + "; path=/; expires=Tue, 31-Dec-2037 00:00:00 GMT; "
 
 	}
 


### PR DESCRIPTION
iOS版Chromeで正しくお気に入りが保存されないバグがあったので、併せて保存先をLocalStorageに変更しました。
（長期的にお気に入りを保存する可能性があるため、期限を意識する必要がなくなるから）