### PR TITLE
履修仮組み機能に関するバグフィックス

### DIFF
--- a/bookmark.css
+++ b/bookmark.css
@@ -202,3 +202,32 @@
 #bookmark-timetable footer:hover {
 	color: #ccc;
 }
+
+/* bookmark information */
+#bookmark-info {
+	color: #fff;
+	font-size: 0.8rem;
+	margin-top: -0.4rem;
+	padding: 0.4rem 0.6rem;
+	border-radius: 4px;
+	box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+	background: rgba(0,0,0,0.6);
+	opacity: 0;
+	position: fixed;
+	top: 2rem;
+	left: 2rem;
+	transition: opacity 0.3s linear;
+}
+
+#bookmark-info:before {
+	content: "";
+	border-style: solid;
+	border-width: 8px 8px 8px 0;
+	border-color: transparent rgba(0,0,0,0.4) transparent transparent;
+	position: absolute;
+	left: -8px;
+}
+
+#bookmark-info h4, #bookmark-info p {
+	margin: 0;
+}

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 			</table>
 		</main>
 		<footer>
-			Contributed by <a href="https://github.com/inaniwaudon">いなにわうどん</a>, <a href="https://github.com/frodo821">frodo821</a>, <a href="https://github.com/eggplants">eggplants</a>, <a href="https://github.com/maru2213">maru2213</a>, et al.<!--
+			Contributed by <a href="https://github.com/inaniwaudon">いなにわうどん</a>, <a href="https://github.com/frodo821">frodo821</a>, <a href="https://github.com/eggplants">eggplants</a>, <a href="https://github.com/maru2213">maru2213</a>, <a href="https://github.com/itsu-dev">Itsu</a>, <a href="https://github.com/Mimori256">Mimori256</a>a et al.<!--
 			--><span style="margin: 0 1rem;">/</span><!--
 			--><a href="javascript:void(0)" id="download">CSVダウンロード</a><br/>
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,13 @@
 		</footer>
 	</div>
 
+	<div id="bookmark-info">
+		<h4>ブックマークに追加できます</h4>
+		<p>ブックマークした科目は<br/>
+			右側の時間割に表示され、<br/>
+			履修の仮組みに利用可能です。</p>
+	</div>
+
 	<div id="bookmark-timetable">
 		<div class="main">
 			<header>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ window.onload = function () {
 	let submitButton = document.getElementById("submit");
 	const downloadLink = document.getElementById("download");
 	const updatedDate = document.getElementById("updated-date");
+	const bookmarkInfo = document.getElementById("bookmark-info");
 
 	//clear button
 	let clearButton = document.getElementById("clear");
@@ -589,10 +590,31 @@ window.onload = function () {
 
 		search(null);
 		updatedDate.innerHTML = updated;
+
+		// bookmark
 		bookmarkTable = new BookmarkTimetable();
 		bookmarkTable.update();
+
+		let firstBookmark = document.querySelector("input.bookmark");
+		if (!isUnder1100px && localStorage.getItem("kdb_bookmarks") == null)
+			bookmarkInfo.style.opacity = 1;
+		else
+			bookmarkInfo.style.display = "none";
+
+		let bounding = firstBookmark.getBoundingClientRect();
+		bookmarkInfo.style.left = bounding.left + 28 + "px";
+		bookmarkInfo.style.top = bounding.top + 4 + "px";
 	})();
 
+
+	// scroll
+	window.addEventListener("scroll", () => {
+		bookmarkInfo.style.opacity = 0;
+		setTimeout(() => bookmarkInfo.style.display = "none", 300);
+	});
+
+
+	// resize
 	window.addEventListener('resize', () => {
 		let supportsTouch = "ontouchend" in document
 		timetableLink.removeEventListener(supportsTouch ? "touchstart" : "click", timetableListener)

--- a/script.js
+++ b/script.js
@@ -679,8 +679,12 @@ const removeAllBookmarks = () => {
 		return;
 
 	const bookmarks = getBookmarks();
-	for (let subjectId of bookmarks)
+	for (let subjectId of bookmarks) {
 		removeBookmark(subjectId);
+		let bookmark = document.getElementById("bookmark-" + subjectId);
+		if (bookmark != null)
+			bookmark.checked = false;
+	}
 	bookmarkTable.update();
 }
 

--- a/script.js
+++ b/script.js
@@ -681,7 +681,7 @@ function onBookmarkChanged(event) {
 
 	bookmarkTable.update();
 	if (subjectMap[subjectId].terms.length > 0 && subjectMap[subjectId].terms[0].length > 0)
-		bookmarkTable.switchTimetable(subjectMap[subjectId].terms[0]);
+		bookmarkTable.switchTimetable(subjectMap[subjectId].terms[0][0]);
 }
 
 const removeAllBookmarks = () => {
@@ -833,7 +833,8 @@ class BookmarkTimetable {
 										remove.classList.remove("displayed");
 									});
 									remove.addEventListener("click", () => {
-										this.remove(code);
+										removeBookmark(code);
+										this.update();
 									});
 								}
 							}

--- a/script.js
+++ b/script.js
@@ -674,7 +674,11 @@ function onBookmarkChanged(event) {
 }
 
 const removeAllBookmarks = () => {
-	let bookmarks = getBookmarks();
+	const isApproved = window.confirm("すべてのお気に入りの科目が削除されます。よろしいですか？");
+	if (!isApproved)
+		return;
+
+	const bookmarks = getBookmarks();
 	for (let subjectId of bookmarks)
 		removeBookmark(subjectId);
 	bookmarkTable.update();

--- a/style.css
+++ b/style.css
@@ -354,6 +354,7 @@ input[type="checkbox"].bookmark  {
 	position: relative;
 	vertical-align: middle;
 	margin-bottom: 0.2em;
+	cursor: pointer;
 }
 
 input[type="checkbox"].bookmark:before {


### PR DESCRIPTION
Issues #33 に関するバグ修正が中心です。

1. #32 で指摘されていた、履修仮組み機能の表示に関するバグ修正を行いました。
シラバスと突き合わせて検証したところ、開講時限のデリミタとして以下のものが存在していました。
- ` `（半角スペース）：モジュール群？（春ABのように一つの固まり）毎の時限の区切り
- `・`：曜日の列挙
- `,`：時間（n限）の区切り

2. ｢すべて削除」時の★マークの表示を同期しました。
また、｢すべて削除」を押した際にアラート（`すべてのお気に入りの科目が削除されます。よろしいですか？`）で確認するようにしました。

3. お気に入りボタンの説明を追加しました。
`!isUnder1100px` かつ、ブックマーク機能に関するLocalStrogeが `null` の場合にのみ表示されます。
スクロールで自然消滅します。
<img src="https://user-images.githubusercontent.com/69859801/120904065-0282ab00-c685-11eb-8be8-690766f2eb0f.png" width="400px"/>

4. フッター部分 `Contributed by ...` の記述を更新しました。