### PR TITLE
時間割からお気に入りを削除したとき星マークを同期

### DIFF
--- a/script.js
+++ b/script.js
@@ -856,6 +856,9 @@ class BookmarkTimetable {
 									});
 									remove.addEventListener("click", () => {
 										removeBookmark(code);
+										let bookmark = document.getElementById("bookmark-" + code);
+										if (bookmark != null)
+											bookmark.checked = false;
 										this.update();
 									});
 								}


### PR DESCRIPTION
仮組みの時間割から授業を削除するとき、★マークの変更が同期されていなかったので修正しました。