### PR TITLE
GitHub Actionsの細かい修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CSV scheduled update
 
 on:
   schedule:
-  - cron: '0 0 * * 0'
+  - cron: '0 15 * * 6'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          setup-python: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,16 @@ jobs:
           python -m pip install -U pip
           pip install -r src/requirements.txt
       - name: Synchronize the csv file with an up-to-date one
+        env:
+          TZ: Asia/Tokyo
         run: |
           cd src
           python download.py
           python csv-json.py "../csv/kdb-$(date +%Y%m%d).csv" list.txt
           cd ..
       - name: Pull and Commit
+        env:
+          TZ: Asia/Tokyo
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"


### PR DESCRIPTION
- タイムゾーンに`Asia/Tokyo`を指定しました。
- cronはGMT(UTC)でスケジュールする必要があるようです。JST(GMT+9)における毎週日曜日0時は、GMTにおける毎週土曜日15時なので、そのように指定し直しました。
- Pythonのセットアップをする際、`Warning: Unexpected input(s) 'setup-python', valid inputs are ['python-version', 'architecture']`というWarningが出ていたので修正しました。`architecture`はoptionalなので追加していません。