### PR TITLE
fix: push commit from CI to protected branch with token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -40,9 +42,5 @@ jobs:
           git config --global user.name "GitHub Action"
           git add .
           git commit -m "update csv: $(date +%Y%m%d)"
-          git pull origin ${{ github.ref }}
       - name: Push
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GH_ADMIN_TOKEN }}
-          branch: ${{ github.ref }}
+        run: git push


### PR DESCRIPTION
Actionsによるprotected branch(master)へのPushがうまく行かない問題の解決です。
「Checkout時にtokenを指定してみるとうまくいくかも」を試してみます。
参考: <https://stackoverflow.com/questions/59604922>