### PR TITLE
CSV出力の修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -404,15 +404,18 @@ window.onload = function() {
 			row.length = 0;
 			for (let c = 0; c < table_.rows[r].cells.length; c++) {
 				field = table_.rows[r].cells[c].innerText.trim();
-				if (r !== 0 && c === 0) {
-					field = field.slice(0, -5);
-				}
+				field = field.replace("シラバスシラバス（ミラー)", "");
 				row.push(
 					escaped.test(field) ? '"' + field.replace(e, '""') + '"' : field
 				);
+                          
 			}
-			csv.push(row.join(","));
+			csv.push(row.join(",").replace('\n",', '",'));
+			
 		}
+
+
+
 		var blob = new Blob([bom, csv.join("\n")], { type: "text/csv" });
 
 		if (window.navigator.msSaveBlob) {

--- a/script.js
+++ b/script.js
@@ -414,8 +414,6 @@ window.onload = function() {
 			
 		}
 
-
-
 		var blob = new Blob([bom, csv.join("\n")], { type: "text/csv" });
 
 		if (window.navigator.msSaveBlob) {


### PR DESCRIPTION
CSVをダウンロードすると、シラバスのミラーを作ったことにより、前とフォーマットが変わり、scs移行要件ツール(https://itsu-dev.github.io/scs-migration-checker/) が正常に動作しなくなっていたので、csvの出力を前のフォーマットに戻すように変更しました。
https://mimori256.github.io/alternative-tsukuba-kdb/# からデプロイしたものを確認できます。