### PR TITLE
シラバスをページ内で開けるように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 		/>
 		<link href="style.css" rel="stylesheet" />
 		<link href="bookmark.css" rel="stylesheet" />
+		<script src="window.js"></script>
 		<script src="script.js"></script>
 	</head>
 

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 let subjectMap = {};
 let bookmarkTable;
 
-window.onload = function() {
+window.onload = function () {
 	const table = document.querySelector("table#body tbody");
 	const keyword_input = document.querySelector('input[type="text"]');
 	const form = document.getElementsByTagName("form")[0];
@@ -258,6 +258,15 @@ window.onload = function() {
 
 		tr.innerHTML += `<td>${line.abstract}</td>`;
 		tr.innerHTML += `<td>${line.note}</td>`;
+
+		let anchor = tr.children.item(0).children.item(3);
+
+		anchor.addEventListener('click', (evt) => {
+			evt.preventDefault();
+			let win = document.createElement('draggable-window');
+			win.innerHTML = `<div slot="title">${line.name} - シラバス</div><iframe slot="body" src=\"${anchor.href}\" />`;
+			document.body.append(win);
+		})
 	};
 
 	// update the table
@@ -270,7 +279,7 @@ window.onload = function() {
 
 		if (isIOS && displayedIndex >= lineLimit) return;
 
-		for (;;) {
+		for (; ;) {
 			const line = data[index];
 
 			if (typeof line === "undefined") {
@@ -297,10 +306,10 @@ window.onload = function() {
 			let matchesKeyword =
 				options.keyword != "" &&
 				matchesNo &&
-					matchesName &&
-					matchesRoom &&
-					matchesPerson &&
-					matchesAbstract;
+				matchesName &&
+				matchesRoom &&
+				matchesPerson &&
+				matchesAbstract;
 
 			// period
 			let missMatchesPeriod = true;
@@ -408,10 +417,10 @@ window.onload = function() {
 				row.push(
 					escaped.test(field) ? '"' + field.replace(e, '""') + '"' : field
 				);
-                          
+
 			}
 			csv.push(row.join(",").replace('\n",', '",'));
-			
+
 		}
 
 		var blob = new Blob([bom, csv.join("\n")], { type: "text/csv" });

--- a/style.css
+++ b/style.css
@@ -385,3 +385,9 @@ input[type="checkbox"].bookmark:before {
 input[type="checkbox"].bookmark:checked {
 	color: #60c;
 }
+
+iframe {
+	border: none;
+	width: 100%;
+	height: 100%;
+}

--- a/window.js
+++ b/window.js
@@ -1,0 +1,115 @@
+class DraggableWindow extends HTMLElement {
+  constructor() {
+    super();
+    this.start = null;
+    this.windowElement = null;
+  }
+
+  connectedCallback() {
+    let shadow = this.attachShadow({ 'mode': 'closed' });
+    let style = document.createElement('style');
+
+    style.innerHTML = `
+    .window {
+      position: fixed;
+      display: block;
+      top: 0;
+      resize: both;
+      background: white;
+      padding: 0.2rem;
+      z-index: 5;
+      border: solid 2px;
+      border-radius: 0.3rem;
+      overflow: hidden;
+      display: grid;
+      grid-template-rows: 1.2rem 1fr;
+      cursor: grab;
+    }
+    .window .controls {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: block;
+      height: 1.1rem;
+      padding-top: 0.1rem;
+      cursor: initial;
+    }
+    .window .controls li:not(.title) {
+      width: 0.8rem;
+      height: 0.8rem;
+      border-radius: 50%;
+      border: solid 1px #1e1e2a49;
+      cursor: pointer;
+    }
+    .window .controls li {
+      float: left;
+      margin-left: 0.1rem;
+    }
+    .window .controls li.title {
+      font-size: 0.8rem;
+      text-align: center;
+      display: grid;
+      width: calc(100% - 2rem);
+      word-break: keep-all;
+      white-space: pre;
+      text-overflow: ellipsis;
+    }
+    .window .body {
+      cursor: initial;
+    }
+    `
+
+    shadow.append(style)
+
+    let win = document.createElement('div');
+    win.className = 'window';
+    win.draggable = true;
+    win.addEventListener('dragstart', this.dragStart.bind(this));
+    win.addEventListener('dragend', this.dragEnd.bind(this));
+    this.windowElement = win;
+
+    let controls = document.createElement('ul');
+    controls.className = 'controls';
+    controls.innerHTML = `
+    <li style="background: radial-gradient(circle, rgb(255,0,0) 0%, rgb(255,231,192) 100%);"></li>
+    <!--li style="background: radial-gradient(circle, rgb(255,255,0) 0%, rgb(255,255,0) 25%, rgb(227,255,228) 100%);"></li>
+    <li style="background: radial-gradient(circle, rgb(0,255,0) 0%, rgb(0,255,0) 25%, rgb(215,255,254) 100%)"></li-->
+    <li class="title"><slot name="title"></slot></li>`;
+
+    controls.children.item(0).addEventListener('click', () => this.remove());
+
+    let body = document.createElement('div');
+    body.className = 'body';
+    body.innerHTML = '<slot name="body"></slot>';
+
+    win.append(controls);
+    win.append(body);
+
+    shadow.append(win);
+  }
+
+  /**
+   * @param {DragEvent} evt
+   */
+  dragStart(evt) {
+    this.start = [evt.pageX, evt.pageY];
+    console.log("start", this.start);
+  }
+
+  /**
+   * @param {DragEvent} evt
+   */
+  dragEnd(evt) {
+    console.log("end", this.start);
+    let delta = [evt.pageX - this.start[0], evt.pageY - this.start[1]];
+    let currentLeft = parseFloat(getComputedStyle(this.windowElement).left.slice(0, -2)) || 0;
+    let currentTop = parseFloat(getComputedStyle(this.windowElement).top.slice(0, -2)) || 0;
+    this.windowElement.style.left = `${delta[0] + currentLeft}px`;
+    this.windowElement.style.top = `${delta[1] + currentTop}px`;
+    this.start = null;
+  }
+}
+
+if ('customElements' in window) {
+  customElements.define('draggable-window', DraggableWindow);
+}


### PR DESCRIPTION
## 変更の要約
シラバスをページ内で開けるように修正しました。

## 変更の動機
詳細なシラバスを見る際に、ほかのページへの遷移ないしはタブを新しく開かないとみることができないことが若干のストレスだったこと。画面内でシラバスを見られると便利だと考えた。

## 変更の詳細
ミラー版シラバスのボタンをクリックすると、その内容がドラッグして移動できるポップアップウィンドウに表示される。

## 申し送り事項・その他備考
スマホ向けに調整していないので、どなたかが調整していただけると助かります。