### PR TITLE
remove an event of pull_request from the CI to build

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,10 +1,8 @@
 name: Build
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- 現在の設定ではPRを送った段階でデプロイに反映されてしまい、悪用されるとかなり危険なので修正