### PR TITLE
要件の部分の検索機能を修正

### DIFF
--- a/src/subject/index.ts
+++ b/src/subject/index.ts
@@ -32,9 +32,9 @@ export class Subject {
     this.person = line[8];
     this.abstract = line[9];
     this.note = line[10];
-    this.reqA = line[11];
-    this.reqB = line[12];
-    this.reqC = line[13];
+    this.reqA = line[13];
+    this.reqB = line[14];
+    this.reqC = line[15];
 
     // term (season - module)
     // term code

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,13 @@
-type RepeatedTuple<T, N extends number> = N extends N ? number extends N ? T[] : RepeatedTupleImpl<T, N, []> : never;
-type RepeatedTupleImpl<T, N extends number, R extends unknown[]> = R['length'] extends N ? R : RepeatedTupleImpl<T, N, [T, ...R]>;
-
+type RepeatedTuple<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : RepeatedTupleImpl<T, N, []>
+  : never;
+type RepeatedTupleImpl<T, N extends number, R extends unknown[]> = R['length'] extends N
+  ? R
+  : RepeatedTupleImpl<T, N, [T, ...R]>;
 
 export interface KdbData {
   updated: string;
-  subject: RepeatedTuple<string, 14>[];
+  subject: RepeatedTuple<string, 16>[];
 }


### PR DESCRIPTION
- 新年度の改訂？なのか、本家kdbが吐き出すデータが
`"科目番号","科目名","授業方法","単位数","標準履修年次","実施学期","曜時限","教室","担当教員","授業概要","備考","科目等履修生申請可否","申請条件","英語(日本語)科目名","科目コード","要件科目名","データ更新日"`
から
`"科目番号","科目名","授業方法","単位数","標準履修年次","実施学期","曜時限","教室","担当教員","授業概要","備考","科目等履修生申請可否","申請条件","短期留学生申請可否","申請条件","英語(日本語)科目名","科目コード","要件科目名","データ更新日"  
`
に変更され、自動生成される JSON のインデックスがずれています
- 一旦クライアント側で読むインデックスを修正しました