### PR TITLE
Fix/match specials conditions

### DIFF
--- a/src/subject/search.ts
+++ b/src/subject/search.ts
@@ -54,7 +54,10 @@ export function matchesSearchOptions(subject: Subject, options: SearchOptions): 
       options.disablePeriods != null &&
       subject.periodsArray.some((periods) => periods.matches(options.disablePeriods!), false)
     ) &&
-    (options.periods.length == 0 ||
+    ((options.periods.length == 0 &&
+      !options.concentration &&
+      !options.negotiable &&
+      !options.asneeded) ||
       subject.periodsArray.some((periods) => periods.matches(options.periods), false) ||
       (options.concentration && subject.concentration) ||
       (options.negotiable && subject.negotiable) ||

--- a/src/subject/search.ts
+++ b/src/subject/search.ts
@@ -49,7 +49,7 @@ export function matchesSearchOptions(subject: Subject, options: SearchOptions): 
     matchesNote;
 
   // period
-  let matchesPeriods =
+  const matchesPeriods =
     !(
       options.disablePeriods != null &&
       subject.periodsArray.some((periods) => periods.matches(options.disablePeriods!), false)
@@ -61,26 +61,27 @@ export function matchesSearchOptions(subject: Subject, options: SearchOptions): 
       (options.asneeded && subject.asneeded));
 
   // standard year of course
-  let matchesYear;
-  if (options.year == 'null') {
-    matchesYear = true;
-  } else if (subject.year.indexOf('-') == -1) {
-    matchesYear = subject.year.indexOf(options.year) > -1;
-  } else {
-    let minYear = subject.year.replace(/\s-\s[1-6]/g, '');
-    let maxYear = subject.year.replace(/[1-6]\s-\s/g, '');
-    matchesYear = minYear <= options.year && options.year <= maxYear;
-  }
+  const matchesYear = (() => {
+    if (options.year == 'null') {
+      return true;
+    } else if (subject.year.indexOf('-') == -1) {
+      return subject.year.indexOf(options.year) > -1;
+    } else {
+      const minYear = subject.year.replace(/\s-\s[1-6]/g, '');
+      const maxYear = subject.year.replace(/[1-6]\s-\s/g, '');
+      return minYear <= options.year && options.year <= maxYear;
+    }
+  })();
 
   // requirements
-  let matchesReqA = options.reqA == 'null' || options.reqA == subject.reqA;
-  let matchesReqB = options.reqB == 'null' || options.reqB == subject.reqB;
-  let matchesReqC = options.reqC == 'null' || options.reqC == subject.reqC;
+  const matchesReqA = options.reqA == 'null' || options.reqA == subject.reqA;
+  const matchesReqB = options.reqB == 'null' || options.reqB == subject.reqB;
+  const matchesReqC = options.reqC == 'null' || options.reqC == subject.reqC;
 
   // term
-  let matchesSeason = options.season == null || subject.termStr.indexOf(options.season) > -1;
-  let matchesModule = options.module == null || subject.termStr.indexOf(options.module) > -1;
-  let matchesTerm =
+  const matchesSeason = options.season == null || subject.termStr.indexOf(options.season) > -1;
+  const matchesModule = options.module == null || subject.termStr.indexOf(options.module) > -1;
+  const matchesTerm =
     options.season && options.module
       ? subject.termCodes.some((codes) =>
           codes.includes(getTermCode(options.season!, options.module!))


### PR DESCRIPTION
#189

通常の時程（月曜 2 限等）が未選択でかつ、「集中」「横断」「随時」のいずれか（または複数）が選択中の場合に、何も選択していない場合と同様に、すべての授業がマッチしてしまいます。

したがって、時程選択に関する検索機能の挙動を以下の通りに変更します（太字が変更点）。

| 選択条件 | 結果 |
| --- | --- |
| すべて未選択 | すべての授業を表示 |
| 「月曜 2 限」を選択 | 月曜 2 限の授業を表示 |
| 「集中」を選択 | **集中授業のみを表示** |
|「集中」「横断」を選択 | **集中授業または横断授業のいずれかを表示** |
|「月曜 2 限」「集中」を選択 | 月曜 2 限または集中授業を表示 |

また、`let` が使用されていた箇所を `const` を使用するようにリファクタリングしました。