### PR TITLE
urllib3が2系にアップグレードされたことにより起きるCIのエラーを修正

### DIFF
--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,1 +1,2 @@
 requests
+urllib3 < 2


### PR DESCRIPTION
関連イシュー:  #197
urllib3のバージョンを1系にすることで、また正常に動くようになることを確認しました。