### PR TITLE
シラバスの年度を修正

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/src/subject/index.ts
+++ b/src/subject/index.ts
@@ -22,8 +22,6 @@ const isModule = (char: string): char is Modules => (modules as readonly string[
 export const getTermCode = (season: NormalSeasons, char: Modules) =>
   (season == '春' ? 0 : 3) + (char == 'A' ? 0 : char == 'B' ? 1 : 2);
 
-const date = new Date();
-
 export class Subject {
   private _code: string;
   private _name: string;
@@ -122,7 +120,12 @@ export class Subject {
   }
 
   get syllabusHref() {
-    return `https://kdb.tsukuba.ac.jp/syllabi/${date.getFullYear()}/${this.code}/jpn`;
+    // We manually updated the following year.
+    // That is because it may refer to a unpublished syllabus,
+    // in case that we the fiscal year is retrieved from the current date,
+    // Official syllabi are updated manually in early April.
+    const year = 2023;
+    return `https://kdb.tsukuba.ac.jp/syllabi/${year}/${this.code}/jpn`;
   }
 }
 


### PR DESCRIPTION
fix: #206

年は明けたものの年度は変わっていないため、`date.getFullYear()` では（現時点でまだ公開されていない）来年度のシラバスへと飛んでしまいます。

新年度もシラバスは丁度 4/1 に公開されるとは限らないことに鑑みて、この年度は手動で更新する方針とします。