### PR TITLE
時間割クリック時にシラバスを開けるようにした

### DIFF
--- a/frontend/src/components/Timetable/Index.tsx
+++ b/frontend/src/components/Timetable/Index.tsx
@@ -120,6 +120,11 @@ const SubjectTile = styled.div<{ background: string; top: number }>`
   top: ${({ top }) => 3 + top}px;
   left: 3px;
 
+  a {
+    color: #000;
+    text-decoration: none;
+  }
+
   &:hover .close {
     display: block;
   }
@@ -310,9 +315,15 @@ const TimetableElement = ({
                       top={subjecti * 2}
                       key={subject.code}
                     >
-                      {subject.code}
-                      <br />
-                      {subject.name}
+                      <a
+                        href={subject.syllabusHref}
+                        target="_blank"
+                        rel="nofollow noopener noreferrer"
+                      >
+                        {subject.code}
+                        <br />
+                        {subject.name}
+                      </a>
                       <Close
                         className="close"
                         onClick={() => switchBookmark(subject.code)}


### PR DESCRIPTION
時間割の（✕ 以外の）部分をクリックした際、シラバスを新しいタブで開けるようにしました。#121 で実装されたものとおおよそ同じだと思います（少なくとも見た目の点では）。