### PR TITLE
通年科目を検索にヒット／時間割に表示させる

### DIFF
--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -221,6 +221,11 @@ const matchesTerm = (subject: Subject, options: SearchOptions) => {
   const season = options.season;
   const module = options.module;
 
+  // 通年の場合はマッチ
+  if (subject.termStr.includes("通年")) {
+    return true;
+  }
+
   // 学期、モジュールが両方指定されている場合は組み合わせで検索
   if (season && module) {
     return subject.termCodes.some((codes) =>

--- a/frontend/src/utils/subject.ts
+++ b/frontend/src/utils/subject.ts
@@ -130,7 +130,15 @@ export class Subject {
       const group: number[] = [];
       const charArray = Array.from(groupStr);
 
-      for (const char of charArray) {
+      for (let i = 0; i < charArray.length; i++) {
+        const char = charArray[i];
+        const nextChar = charArray[i + 1];
+
+        // 通年の場合は春 A-C，秋A-C を入れる
+        if (char === "通" && nextChar === "年") {
+          group.push(0, 1, 2, 3, 4, 5);
+          continue;
+        }
         // 季節が出現した場合、以降のタームはその季節として扱う
         if (isAllSeason(char)) {
           season = char;


### PR DESCRIPTION
タームに「通年」と表記されている科目が検索にヒットしなかったり，お気に入りに追加しても時間割に表示されないバグを修正します．
fix: #328