### PR TITLE
時間割の表示を修正

### DIFF
--- a/frontend/src/utils/timetable.ts
+++ b/frontend/src/utils/timetable.ts
@@ -41,6 +41,7 @@ export const createTimeslotTable = (value: string): TimeslotTable => {
   const table = fillTimetable(false);
   let dayArray: number[] = [];
 
+  // ｛曜日 + 数字（ハイフン含む）｝がコンマ区切りで繰り返される
   // コンマで分割
   // TODO: check
   const slotStrArray = (value as string).split(",");
@@ -59,6 +60,7 @@ export const createTimeslotTable = (value: string): TimeslotTable => {
     const periodArray: number[] = [];
     const periodStr = slotStr.replace(/[^0-9\\-]/g, "");
 
+    // - が含まれる場合は範囲選択
     if (periodStr.indexOf("-") > -1) {
       const periodStrArray = periodStr.split("-");
       const startPeriod = Number(periodStrArray[0]);

--- a/frontend/src/utils/useBookmark.ts
+++ b/frontend/src/utils/useBookmark.ts
@@ -133,20 +133,23 @@ export const useBookmark = (
       if (termIndex === -1) {
         continue;
       }
+
       const subjectTimeslotTable = subject.timeslotTables[termIndex];
-      for (let day = 0; day < table.length; day++) {
-        for (let period = 0; period < table[day].length; period++) {
-          // 科目がコマを含めば追加
-          if (subjectTimeslotTable[day][period]) {
-            table[day][period] = true;
-            subjectTable[day][period].push(subject);
+      if (subjectTimeslotTable) {
+        for (let day = 0; day < table.length; day++) {
+          for (let period = 0; period < table[day].length; period++) {
+            // 科目がコマを含めば追加
+            if (subjectTimeslotTable[day][period]) {
+              table[day][period] = true;
+              subjectTable[day][period].push(subject);
+            }
           }
         }
+        timeslots += getTimeslotsLength(subjectTimeslotTable);
       }
       if (!bookmarkSubject.ta) {
         credits += subject.credit;
       }
-      timeslots += getTimeslotsLength(subjectTimeslotTable);
     }
     return [table, subjectTable, credits, timeslots];
   }, [bookmarks, timetableTermCode]);


### PR DESCRIPTION
fix: #687 

KdB が提供する科目情報は、ターム（春秋ABC）とコマ（曜日・時限）がスペースによって区切られており、ほとんどの科目において、この配列長は一致しています。
例えば `春A 春B`, `金3 金4` という科目があった場合は、春A金3、春B金4 と解釈できます。

しかしながら、稀にタームとコマの配列長が一致しない場合があります。
（例：GC23304 CG基礎 では、`秋AB`, `火3 火4` とコマに余計なスペースが存在する）

今回の修正では、タームまたはコマのうち、一方の配列長が 1 であった場合は、他方も統合して配列長を 1 にすることで、適切に時間割が表示されるように修正します。