### PR TITLE
時間割の表示を修正

### DIFF
--- a/frontend/src/utils/subject.ts
+++ b/frontend/src/utils/subject.ts
@@ -95,9 +95,7 @@ export class Subject {
 
     // コマのグループが 1 つしかない場合は、すべてのタームを統合
     if (this._timeslotTables.length === 1) {
-      this._termCodes = [
-        this._termCodes.flatMap((codes, prev) => [...codes, prev], []),
-      ];
+      this._termCodes = [[...new Set(this._termCodes.flat())]];
     }
 
     this.classMethods = classMethods.filter((it) => this.note.indexOf(it) > -1);


### PR DESCRIPTION
fix: #722 

#721 の修正以降、春Aの時間割にすべての科目が表示されてしまうバグを修正しました。
